### PR TITLE
ScaleDiscreteIdentity fix new ggplot2 version

### DIFF
--- a/R/geom_flag.R
+++ b/R/geom_flag.R
@@ -16,10 +16,9 @@ drawDetails.flag <- function(x, recording=FALSE){
 
 #' @export
 scale_country <- function(..., guide = "legend") {
-  sc <- discrete_scale("country", "identity", scales::identity_pal(), ..., guide = guide)
-  
-  sc$super <- ScaleDiscreteIdentity
-  class(sc) <- class(ScaleDiscreteIdentity)
+  sc <- discrete_scale("country", "identity", scales::identity_pal(), ..., guide = guide,
+                       super = ScaleDiscreteIdentity)
+
   sc
 }
 


### PR DESCRIPTION
I couldn't use `ggflags` with the new `ggplot2` version, this seems to repair it. 